### PR TITLE
feat: Reload Launcher on date change

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -7,17 +7,17 @@
     <uses-sdk
         android:minSdkVersion="16"
         android:targetSdkVersion="23" />
-    
+
     <uses-permission android:name="android.permission.KILL_BACKGROUND_PROCESSES" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="com.android.vending.BILLING" />
-    
+
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name" >
-        		
+
         <activity
             android:name="de.theknut.xposedgelsettings.ui.MainActivity"
             android:label="@string/app_name"
@@ -28,7 +28,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        
+
         <activity
             android:name="de.theknut.xposedgelsettings.ui.AllAppsList"
             android:label="@string/app_name"
@@ -40,7 +40,7 @@
         </activity>
 
         <activity android:name="eu.janmuller.android.simplecropimage.CropImage"/>
-        
+
         <activity
             android:name="de.theknut.xposedgelsettings.ui.AllWidgetsList"
             android:label="@string/app_name"
@@ -50,7 +50,7 @@
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
         </activity>
-        
+
         <activity
             android:name="de.theknut.xposedgelsettings.ui.ChooseAppList"
             android:label="@string/app_name"
@@ -80,7 +80,7 @@
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
         </activity>
-        
+
 		<receiver
 		    android:name="de.theknut.xposedgelsettings.broadcastreceiver.XGELSReceiver"
 		    android:enabled="true"
@@ -96,17 +96,20 @@
 		        <action android:name="android.intent.action.WALLPAPER_CHANGED" />
 		        <category android:name="android.intent.category.DEFAULT" />
 		    </intent-filter>
+        <intent-filter>
+             <action android:name="android.intent.action.DATE_CHANGED" />
+        </intent-filter>
 		</receiver>
 
         <provider
             android:authorities="de.theknut.xposedgelsettings"
             android:exported="true"
             android:name=".contentprovider.XGELSContentProvider" />
-		
+
 		<meta-data
 		    android:name="override_tinted_status_bar_defaults"
 		    android:value="true" />
-        
+
         <meta-data
             android:name="xposedmodule"
             android:value="true"/>

--- a/src/de/theknut/xposedgelsettings/broadcastreceiver/XGELSReceiver.java
+++ b/src/de/theknut/xposedgelsettings/broadcastreceiver/XGELSReceiver.java
@@ -29,6 +29,12 @@ public class XGELSReceiver extends BroadcastReceiver {
     @SuppressWarnings("deprecation")
     @Override
     public void onReceive(Context context, Intent intent) {
+
+        if (intent.getAction().equals(Intent.ACTION_DATE_CHANGED)) {
+           context.sendBroadcast(new Intent(Common.XGELS_ACTION_RESTART_LAUNCHER));
+           return;
+        }
+
         SharedPreferences prefs = context.getSharedPreferences(Common.PREFERENCES_NAME, Context.MODE_WORLD_READABLE);
 
         if (intent.getAction().equals(Intent.ACTION_WALLPAPER_CHANGED)) {


### PR DESCRIPTION
This fixes an issue with dynamic calendar icons where the icon is not
updated. To workaround this bug a DATE_CHANGED reciever is registered in
the AndroidManifest.xml that will restart the launcher.
